### PR TITLE
Allow handling more than one export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 rust-nbd
 ---
 
-[Network block device](https://en.wikipedia.org/wiki/Network_block_device) protocol implementation in Rust. For now, only one export and not all features are supported in server.
+[Network block device](https://en.wikipedia.org/wiki/Network_block_device) protocol implementation in Rust. Not all features are currently supported in server.
 
 Accepts a `Read`+`Write`+`Seek` as a data to be exposed in server mode. Provides `Read`+`Write`+`Seek` in client mode. Underlying connection is `Read`+`Write`, usage of `bufstream` crate is recommended.
 

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -5,25 +5,28 @@ use std::net::{TcpListener, TcpStream};
 
 use nbd::server::{handshake, transmission, Export};
 
-fn handle_client(data: &mut [u8], mut stream: TcpStream) -> Result<()> {
-    let e = Export {
-        size: data.len() as u64,
-        readonly: false,
-        ..Default::default()
-    };
+fn handle_client(mut stream: TcpStream) -> Result<()> {
+    let data = handshake(&mut stream, |name| {
+        println!("requested export: {name}");
+        let data = name.repeat(1024).into_bytes();
+        Ok(Export {
+            size: data.len() as u64,
+            data,
+            readonly: false,
+            ..Default::default()
+        })
+    })?;
     let pseudofile = Cursor::new(data);
-    handshake(&mut stream, &e)?;
     transmission(&mut stream, pseudofile)?;
     Ok(())
 }
 
 fn main() {
-    let mut data = vec![0; 1_474_560];
     let listener = TcpListener::bind("127.0.0.1:10809").unwrap();
 
     for stream in listener.incoming() {
         match stream {
-            Ok(stream) => match handle_client(&mut data, stream) {
+            Ok(stream) => match handle_client(stream) {
                 Ok(_) => {}
                 Err(e) => {
                     eprintln!("error: {}", e);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,8 +101,7 @@ pub mod server {
 
     pub use super::Export;
 
-    /// Ignores incoming export name, accepts everything
-    /// Export name is ignored, currently only one export is supported
+    /// Passes the requested export name to the provided callback to get the requested export
     pub fn handshake<IO: Write + Read, Data, F: FnOnce(&str) -> Result<Export<Data>>>(mut c: IO, exports: F) -> Result<Data> {
         //let hs_flags = NBD_FLAG_FIXED_NEWSTYLE;
         let hs_flags = NBD_FLAG_FIXED_NEWSTYLE | NBD_FLAG_NO_ZEROES;


### PR DESCRIPTION
This is done by having `handshake` take a callback that returns the `Export` instead of directly taking an `&Export`.

Additionally, `Export` now takes an optional `data` field that can be used to return info about the requested export from the callback to the calling function. In the example this is the full data `Vec`, but another use case would be using it to pass a filename to open.