### PR TITLE
Reject NBD_OPT_EXTENDED_HEADERS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,6 +192,9 @@ pub mod server {
                 NBD_OPT_STRUCTURED_REPLY => {
                     reply(&mut c, clopt, NBD_REP_ERR_UNSUP, b"")?;
                 }
+                NBD_OPT_EXTENDED_HEADERS => {
+                    reply(&mut c, clopt, NBD_REP_ERR_UNSUP, b"")?;
+                }
                 _ => {
                     strerror("Invalid client option type")?;
                 }
@@ -596,6 +599,7 @@ mod consts {
     pub const NBD_OPT_INFO: u32 = 6;
     pub const NBD_OPT_GO: u32 = 7;
     pub const NBD_OPT_STRUCTURED_REPLY: u32 = 8;
+    pub const NBD_OPT_EXTENDED_HEADERS: u32 = 11;
 
     pub const NBD_REP_ACK: u32 = 1;
     pub const NBD_REP_SERVER: u32 = 2;


### PR DESCRIPTION
qemu requests this now. Instead of aborting the handshake, the request should simply be rejected.